### PR TITLE
Update taplo linting

### DIFF
--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -37,7 +37,7 @@ jobs:
             args: --release
           - name: Taplo
             command: install
-            args: taplo-cli --locked && taplo lint
+            args: taplo-cli --locked && taplo fmt --check
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v4

--- a/esp32-projects/Cargo.toml
+++ b/esp32-projects/Cargo.toml
@@ -49,7 +49,7 @@ unused_must_use = "allow"
 inline_always = { level = "allow", priority = 1 }
 missing_errors_doc = { level = "allow", priority = 1 }
 must_use_candidate = { level = "allow", priority = 1 }
-uninlined_format_args = { level = "allow", priority = 1 }
 nursery = "warn"
 pedantic = "warn"
 suspicious = "deny"
+uninlined_format_args = { level = "allow", priority = 1 }


### PR DESCRIPTION
Fixes Taplo lint CI check to validate TOML is formatted (not validate against a schema / lint for syntax errors)